### PR TITLE
Add PostgreSQL infrastructure automation for OpenShift

### DIFF
--- a/agent-os/product/roadmap.md
+++ b/agent-os/product/roadmap.md
@@ -1,6 +1,6 @@
 # Product Roadmap
 
-1. [ ] **PostgreSQL Database Setup** — Configure PostgreSQL database in OpenShift with proper schema for storing positive thoughts, including tables for thoughts and ratings with appropriate indexes and constraints. `S`
+1. [x] **PostgreSQL Database Setup** — Configure PostgreSQL database in OpenShift with proper schema for storing positive thoughts, including tables for thoughts and ratings with appropriate indexes and constraints. `S`
 
 2. [x] **Thoughts Service Backend** — Create Quarkus microservice with REST endpoints for CRUD operations on positive thoughts, connecting to PostgreSQL database with proper entity mapping and transaction management. `M`
 

--- a/infrastructure/postgresql/01-secret.yml
+++ b/infrastructure/postgresql/01-secret.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-credentials
+  labels:
+    app: postgresql
+    app.kubernetes.io/part-of: positive-thoughts
+type: Opaque
+stringData:
+  POSTGRESQL_USER: thoughts
+  POSTGRESQL_PASSWORD: thoughts
+  POSTGRESQL_DATABASE: thoughts_db

--- a/infrastructure/postgresql/02-pvc.yml
+++ b/infrastructure/postgresql/02-pvc.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgresql-data
+  labels:
+    app: postgresql
+    app.kubernetes.io/part-of: positive-thoughts
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/infrastructure/postgresql/03-deployment.yml
+++ b/infrastructure/postgresql/03-deployment.yml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgresql
+  labels:
+    app: postgresql
+    app.kubernetes.io/part-of: positive-thoughts
+    app.openshift.io/runtime: postgresql
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: postgresql
+  template:
+    metadata:
+      labels:
+        app: postgresql
+    spec:
+      containers:
+        - name: postgresql
+          image: registry.redhat.io/rhel9/postgresql-16:latest
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRESQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql-credentials
+                  key: POSTGRESQL_USER
+            - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql-credentials
+                  key: POSTGRESQL_PASSWORD
+            - name: POSTGRESQL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql-credentials
+                  key: POSTGRESQL_DATABASE
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 250m
+            limits:
+              memory: 512Mi
+              cpu: 500m
+          volumeMounts:
+            - name: postgresql-data
+              mountPath: /var/lib/pgsql/data
+          livenessProbe:
+            exec:
+              command:
+                - /usr/libexec/check-container
+                - --live
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - /usr/libexec/check-container
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 5
+      volumes:
+        - name: postgresql-data
+          persistentVolumeClaim:
+            claimName: postgresql-data

--- a/infrastructure/postgresql/04-service.yml
+++ b/infrastructure/postgresql/04-service.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgresql
+  labels:
+    app: postgresql
+    app.kubernetes.io/part-of: positive-thoughts
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5432
+      targetPort: 5432
+      protocol: TCP
+      name: postgresql
+  selector:
+    app: postgresql

--- a/infrastructure/postgresql/README.md
+++ b/infrastructure/postgresql/README.md
@@ -1,0 +1,85 @@
+# PostgreSQL Database Setup
+
+Automated provisioning of PostgreSQL on OpenShift for the Positive Thoughts application.
+
+## Files
+
+| File | Description |
+|---|---|
+| `01-secret.yml` | Secret containing database username, password, and database name |
+| `02-pvc.yml` | PersistentVolumeClaim for PostgreSQL data (default 5Gi) |
+| `03-deployment.yml` | Deployment using Red Hat PostgreSQL 16 image with liveness/readiness probes |
+| `04-service.yml` | ClusterIP Service exposing port 5432 for internal access |
+| `setup.sh` | Orchestrator script that applies manifests in order and waits for readiness |
+| `teardown.sh` | Removes all PostgreSQL resources in reverse order |
+
+## Prerequisites
+
+- `oc` CLI installed and authenticated (`oc login`)
+- Available persistent storage (default: 5Gi)
+- Access to pull `registry.redhat.io/rhel9/postgresql-16` (or override with a different image)
+
+## Setup
+
+```bash
+./setup.sh [NAMESPACE]
+```
+
+The namespace defaults to `positive-thoughts` if not provided. The script is idempotent -- safe to re-run.
+
+### What the script does
+
+1. Creates the target namespace (if it doesn't exist)
+2. Creates a Secret with database credentials
+3. Creates a PVC for persistent data
+4. Deploys the PostgreSQL pod
+5. Waits for the deployment rollout to complete
+6. Prints the JDBC connection string for Quarkus services
+
+On completion it prints the connection details:
+
+```
+QUARKUS_DATASOURCE_JDBC_URL=jdbc:postgresql://postgresql.positive-thoughts.svc.cluster.local:5432/thoughts_db
+QUARKUS_DATASOURCE_USERNAME=thoughts
+QUARKUS_DATASOURCE_PASSWORD=thoughts
+```
+
+### Configuration
+
+Override defaults with environment variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `POSTGRESQL_USER` | `thoughts` | Database username |
+| `POSTGRESQL_PASSWORD` | `thoughts` | Database password |
+| `POSTGRESQL_DATABASE` | `thoughts_db` | Database name |
+| `POSTGRESQL_STORAGE_SIZE` | `5Gi` | PVC size |
+| `POSTGRESQL_IMAGE` | `registry.redhat.io/rhel9/postgresql-16:latest` | Container image |
+
+Example with custom credentials and storage:
+
+```bash
+POSTGRESQL_USER=admin POSTGRESQL_PASSWORD=s3cret POSTGRESQL_STORAGE_SIZE=20Gi ./setup.sh my-namespace
+```
+
+### Schema management
+
+This setup only provisions the PostgreSQL instance. Database schema (tables, indexes, constraints) is created automatically by **Flyway migrations** embedded in each Quarkus service on startup. No manual schema setup is needed.
+
+## Teardown
+
+```bash
+./teardown.sh [NAMESPACE]
+```
+
+Removes the service, deployment, PVC, and secret. The namespace is preserved by default.
+
+| Variable | Default | Description |
+|---|---|---|
+| `REMOVE_NAMESPACE` | `false` | Also delete the target namespace |
+
+Full cleanup:
+
+```bash
+REMOVE_NAMESPACE=true ./teardown.sh positive-thoughts
+```

--- a/infrastructure/postgresql/setup.sh
+++ b/infrastructure/postgresql/setup.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# Automated setup for PostgreSQL on OpenShift.
+#
+# Usage:
+#   ./setup.sh [NAMESPACE]
+#
+# Arguments:
+#   NAMESPACE   Target namespace (default: positive-thoughts)
+#
+# Environment variables:
+#   POSTGRESQL_USER          Database username (default: thoughts)
+#   POSTGRESQL_PASSWORD      Database password (default: thoughts)
+#   POSTGRESQL_DATABASE      Database name (default: thoughts_db)
+#   POSTGRESQL_STORAGE_SIZE  PVC size (default: 5Gi)
+#   POSTGRESQL_IMAGE         Container image (default: registry.redhat.io/rhel9/postgresql-16:latest)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NAMESPACE="${1:-positive-thoughts}"
+POSTGRESQL_USER="${POSTGRESQL_USER:-thoughts}"
+POSTGRESQL_PASSWORD="${POSTGRESQL_PASSWORD:-thoughts}"
+POSTGRESQL_DATABASE="${POSTGRESQL_DATABASE:-thoughts_db}"
+POSTGRESQL_STORAGE_SIZE="${POSTGRESQL_STORAGE_SIZE:-5Gi}"
+POSTGRESQL_IMAGE="${POSTGRESQL_IMAGE:-registry.redhat.io/rhel9/postgresql-16:latest}"
+DEPLOY_WAIT_TIMEOUT="120s"
+
+log() { echo "==> $*"; }
+warn() { echo "WARNING: $*" >&2; }
+fail() { echo "ERROR: $*" >&2; exit 1; }
+
+# -------------------------------------------------------------------
+# Preflight checks
+# -------------------------------------------------------------------
+command -v oc >/dev/null 2>&1 || fail "oc CLI not found. Install it from https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/"
+oc whoami >/dev/null 2>&1 || fail "Not logged in to OpenShift. Run 'oc login' first."
+
+log "Target namespace: ${NAMESPACE}"
+log "Database: ${POSTGRESQL_DATABASE}"
+log "User: ${POSTGRESQL_USER}"
+log "Storage: ${POSTGRESQL_STORAGE_SIZE}"
+
+# -------------------------------------------------------------------
+# Step 1: Create namespace if it doesn't exist
+# -------------------------------------------------------------------
+if oc get namespace "${NAMESPACE}" >/dev/null 2>&1; then
+    log "Namespace '${NAMESPACE}' already exists"
+else
+    log "Creating namespace '${NAMESPACE}'..."
+    oc create namespace "${NAMESPACE}"
+fi
+
+oc project "${NAMESPACE}"
+
+# -------------------------------------------------------------------
+# Step 2: Create Secret
+# -------------------------------------------------------------------
+log "Applying database credentials secret..."
+
+cat <<EOF | oc apply -n "${NAMESPACE}" -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-credentials
+  labels:
+    app: postgresql
+    app.kubernetes.io/part-of: positive-thoughts
+type: Opaque
+stringData:
+  POSTGRESQL_USER: "${POSTGRESQL_USER}"
+  POSTGRESQL_PASSWORD: "${POSTGRESQL_PASSWORD}"
+  POSTGRESQL_DATABASE: "${POSTGRESQL_DATABASE}"
+EOF
+
+# -------------------------------------------------------------------
+# Step 3: Create PVC
+# -------------------------------------------------------------------
+log "Applying persistent volume claim (${POSTGRESQL_STORAGE_SIZE})..."
+
+sed \
+    -e "s/storage: 5Gi/storage: ${POSTGRESQL_STORAGE_SIZE}/" \
+    "${SCRIPT_DIR}/02-pvc.yml" | \
+    oc apply -n "${NAMESPACE}" -f -
+
+# -------------------------------------------------------------------
+# Step 4: Deploy PostgreSQL
+# -------------------------------------------------------------------
+log "Deploying PostgreSQL..."
+
+sed \
+    -e "s|image: registry.redhat.io/rhel9/postgresql-16:latest|image: ${POSTGRESQL_IMAGE}|" \
+    "${SCRIPT_DIR}/03-deployment.yml" | \
+    oc apply -n "${NAMESPACE}" -f -
+
+# -------------------------------------------------------------------
+# Step 5: Create Service
+# -------------------------------------------------------------------
+log "Applying service..."
+oc apply -n "${NAMESPACE}" -f "${SCRIPT_DIR}/04-service.yml"
+
+# -------------------------------------------------------------------
+# Step 6: Wait for readiness
+# -------------------------------------------------------------------
+log "Waiting for PostgreSQL deployment to be ready (timeout: ${DEPLOY_WAIT_TIMEOUT})..."
+oc rollout status deployment/postgresql -n "${NAMESPACE}" --timeout="${DEPLOY_WAIT_TIMEOUT}"
+
+log "PostgreSQL is ready"
+
+# -------------------------------------------------------------------
+# Step 7: Verify
+# -------------------------------------------------------------------
+JDBC_URL="jdbc:postgresql://postgresql.${NAMESPACE}.svc.cluster.local:5432/${POSTGRESQL_DATABASE}"
+
+echo ""
+log "PostgreSQL setup complete!"
+echo ""
+echo "  Namespace: ${NAMESPACE}"
+echo "  Service:   postgresql.${NAMESPACE}.svc.cluster.local:5432"
+echo "  Database:  ${POSTGRESQL_DATABASE}"
+echo "  User:      ${POSTGRESQL_USER}"
+echo ""
+echo "  Connect your Quarkus services with:"
+echo "    QUARKUS_DATASOURCE_JDBC_URL=${JDBC_URL}"
+echo "    QUARKUS_DATASOURCE_USERNAME=${POSTGRESQL_USER}"
+echo "    QUARKUS_DATASOURCE_PASSWORD=${POSTGRESQL_PASSWORD}"

--- a/infrastructure/postgresql/teardown.sh
+++ b/infrastructure/postgresql/teardown.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Tears down the PostgreSQL infrastructure created by setup.sh.
+# Removes resources in reverse order: service, deployment, PVC, secret.
+#
+# Usage:
+#   ./teardown.sh [NAMESPACE]
+#
+# Arguments:
+#   NAMESPACE   Target namespace (default: positive-thoughts)
+#
+# Environment variables:
+#   REMOVE_NAMESPACE  Set to "true" to also delete the namespace (default: false)
+
+set -euo pipefail
+
+NAMESPACE="${1:-positive-thoughts}"
+REMOVE_NAMESPACE="${REMOVE_NAMESPACE:-false}"
+
+log() { echo "==> $*"; }
+
+command -v oc >/dev/null 2>&1 || { echo "ERROR: oc CLI not found" >&2; exit 1; }
+oc whoami >/dev/null 2>&1 || { echo "ERROR: Not logged in to OpenShift" >&2; exit 1; }
+
+# -------------------------------------------------------------------
+# Step 1: Delete Service
+# -------------------------------------------------------------------
+log "Deleting PostgreSQL service..."
+oc delete service postgresql -n "${NAMESPACE}" --ignore-not-found=true
+
+# -------------------------------------------------------------------
+# Step 2: Delete Deployment
+# -------------------------------------------------------------------
+log "Deleting PostgreSQL deployment..."
+oc delete deployment postgresql -n "${NAMESPACE}" --ignore-not-found=true
+
+log "Waiting for PostgreSQL pod to terminate..."
+oc wait pod -l app=postgresql -n "${NAMESPACE}" \
+    --for=delete --timeout=60s 2>/dev/null || true
+
+# -------------------------------------------------------------------
+# Step 3: Delete PVC
+# -------------------------------------------------------------------
+log "Deleting persistent volume claim..."
+oc delete pvc postgresql-data -n "${NAMESPACE}" --ignore-not-found=true
+
+# -------------------------------------------------------------------
+# Step 4: Delete Secret
+# -------------------------------------------------------------------
+log "Deleting credentials secret..."
+oc delete secret postgresql-credentials -n "${NAMESPACE}" --ignore-not-found=true
+
+# -------------------------------------------------------------------
+# Step 5: Remove namespace (optional)
+# -------------------------------------------------------------------
+if [ "${REMOVE_NAMESPACE}" = "true" ]; then
+    log "Deleting namespace '${NAMESPACE}'..."
+    oc delete namespace "${NAMESPACE}" --ignore-not-found=true
+else
+    log "Skipping namespace removal (set REMOVE_NAMESPACE=true to remove)"
+fi
+
+echo ""
+log "PostgreSQL teardown complete."


### PR DESCRIPTION
## Summary
- Add automated setup and teardown scripts for deploying PostgreSQL on OpenShift
- Includes K8s manifests: credentials Secret, PVC for persistent storage, Deployment with Red Hat PostgreSQL 16 image and health probes, ClusterIP Service
- Scripts are idempotent, configurable via environment variables (`POSTGRESQL_USER`, `POSTGRESQL_PASSWORD`, `POSTGRESQL_DATABASE`, `POSTGRESQL_STORAGE_SIZE`, `POSTGRESQL_IMAGE`)
- Schema creation handled by Flyway migrations in Quarkus services -- this setup only provisions the database instance
- Mark roadmap item #1 (PostgreSQL Database Setup) as complete

## Files
- `infrastructure/postgresql/01-secret.yml` — Database credentials
- `infrastructure/postgresql/02-pvc.yml` — Persistent storage (default 5Gi)
- `infrastructure/postgresql/03-deployment.yml` — PostgreSQL 16 pod with liveness/readiness probes
- `infrastructure/postgresql/04-service.yml` — ClusterIP Service on port 5432
- `infrastructure/postgresql/setup.sh` — Orchestrator script with readiness gates
- `infrastructure/postgresql/teardown.sh` — Clean removal in reverse order
- `infrastructure/postgresql/README.md` — Usage documentation

## Test plan
- [ ] Verify `setup.sh` creates namespace, secret, PVC, deployment, and service on a fresh OpenShift cluster
- [ ] Verify PostgreSQL pod reaches ready state and accepts connections
- [ ] Verify `teardown.sh` cleanly removes all resources
- [ ] Verify scripts are idempotent (safe to re-run)
- [ ] Verify env var overrides work for credentials, storage size, and image

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)